### PR TITLE
Exclude SML/NJ 110.97 from macOS CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
           # SML/NJ versions before 110.94 do not support 64-bit
           - os: macos-latest
             smlnj-version: 110.87
+          # SML/NJ versions before 110.98 do not support Big Sur
+          - os: macos-latest
+            smlnj-version: 110.97
 
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
`.arch-n-opsys` script for versions below 110.98 do not recognize Big Sur, used as macos-latest in CI.